### PR TITLE
Remove redundant grepprg setup

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -68,11 +68,6 @@ opt.wildignore:append({
     "*/.venv/*",
     "*/venv/*",
 })
-if vim.fn.executable("rg") == 1 then
-    opt.grepprg = "rg --vimgrep --smart-case --follow"
-else
-    opt.grepprg = "grep -n $* /dev/null"
-end
 -- Add asterisks in block comments
 opt.formatoptions:append({ "r" })
 


### PR DESCRIPTION
## Summary
- clean up options to set `grepprg` only once

## Testing
- `selene` *(fails: command not found)*
- `stylua --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9557eb588331b926ef827d2763ba