### PR TITLE
Convert treesitter opts block to table

### DIFF
--- a/lua/optional/treesitter.lua
+++ b/lua/optional/treesitter.lua
@@ -12,71 +12,72 @@ return {
             { "<c-space>", desc = "Increment Selection" },
             { "<bs>", desc = "Decrement Selection", mode = "x" },
         },
-        opts = function()
-            require("nvim-treesitter.configs").setup({
-                modules = {},
-                sync_install = false,
-                ignore_install = {},
-                auto_install = true,
-                autotag = {
-                    enable = true,
+        opts = {
+            modules = {},
+            sync_install = false,
+            ignore_install = {},
+            auto_install = true,
+            autotag = {
+                enable = true,
+            },
+            highlight = {
+                enable = true,
+                additional_vim_regex_highlighting = false,
+                disable = function(_, buf)
+                    local max = 256 * 1024
+                    local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+                    return ok and stats and stats.size > max
+                end,
+            },
+            indent = {
+                enable = true,
+            },
+            incremental_selection = {
+                enable = true,
+                keymaps = {
+                    init_selection = "<C-space>",
+                    node_incremental = "<C-space>",
+                    scope_incremental = false,
+                    node_decremental = "<bs>",
                 },
-                highlight = {
-                    enable = true,
-                    additional_vim_regex_highlighting = false,
-                    disable = function(_, buf)
-                        local max = 256 * 1024
-                        local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
-                        return ok and stats and stats.size > max
-                    end,
-                },
-                indent = {
-                    enable = true,
-                },
-                incremental_selection = {
-                    enable = true,
-                    keymaps = {
-                        init_selection = "<C-space>",
-                        node_incremental = "<C-space>",
-                        scope_incremental = false,
-                        node_decremental = "<bs>",
-                    },
-                },
-                ensure_installed = {
-                    "bash",
-                    "comment",
-                    "css",
-                    "diff",
-                    "fish",
-                    "git_config",
-                    "git_rebase",
-                    "gitcommit",
-                    "gitignore",
-                    "html",
-                    "javascript",
-                    "json",
-                    "latex",
-                    "lua",
-                    "luadoc",
-                    "markdown",
-                    "markdown_inline",
-                    "norg",
-                    "python",
-                    "query",
-                    "regex",
-                    "scss",
-                    "svelte",
-                    "toml",
-                    "tsx",
-                    "typescript",
-                    "typst",
-                    "vim",
-                    "vimdoc",
-                    "vue",
-                    "xml",
-                    "yaml",
-                },
-            })
+            },
+            ensure_installed = {
+                "bash",
+                "comment",
+                "css",
+                "diff",
+                "fish",
+                "git_config",
+                "git_rebase",
+                "gitcommit",
+                "gitignore",
+                "html",
+                "javascript",
+                "json",
+                "latex",
+                "lua",
+                "luadoc",
+                "markdown",
+                "markdown_inline",
+                "norg",
+                "python",
+                "query",
+                "regex",
+                "scss",
+                "svelte",
+                "toml",
+                "tsx",
+                "typescript",
+                "typst",
+                "vim",
+                "vimdoc",
+                "vue",
+                "xml",
+                "yaml",
+            },
+        },
+        config = function(_, opts)
+            require("nvim-treesitter.configs").setup(opts)
         end,
     },
 


### PR DESCRIPTION
## Summary
- keep treesitter options but store them in a table
- call `nvim-treesitter.configs.setup` from a new config function

## Testing
- `stylua lua/optional/treesitter.lua`
- `selene lua/optional/treesitter.lua` *(fails: `unknown field globals`)*

------
https://chatgpt.com/codex/tasks/task_e_684a955c49fc83319b2145d2ed04113d