### PR TITLE
Delay loading for non-critical plugins

### DIFF
--- a/lua/optional/gitsigns.lua
+++ b/lua/optional/gitsigns.lua
@@ -2,7 +2,8 @@
 ---@type LazySpec
 return {
     "lewis6991/gitsigns.nvim",
-    event = { "BufReadPre", "BufWritePre" },
+    -- Delay git integration until files are opened
+    event = { "BufReadPost", "BufNewFile" },
     cmd = { "Gitsigns" },
     keys = {
         { "<leader>gB", "<cmd>Gitsigns toggle_current_line_blame<cr>", desc = "Toggle current line blame" },

--- a/lua/optional/lualine.lua
+++ b/lua/optional/lualine.lua
@@ -4,7 +4,8 @@ return {
     {
         "nvim-lualine/lualine.nvim",
         enabled = true,
-        event = { "BufRead", "BufNewFile" },
+        -- Load statusline late to improve startup time
+        event = "VeryLazy",
         dependencies = {
             { "echasnovski/mini.icons", lazy = true },
         },

--- a/lua/optional/persistence.lua
+++ b/lua/optional/persistence.lua
@@ -1,6 +1,7 @@
 return {
     "folke/persistence.nvim",
-    event = "BufReadPre",
+    -- Only load session management when first needed
+    event = "VeryLazy",
     opts = {
         dir = vim.fn.stdpath("state") .. "/sessions/",
         options = { "buffers", "curdir", "tabpages", "winsize" },

--- a/lua/optional/snacks.lua
+++ b/lua/optional/snacks.lua
@@ -3,7 +3,8 @@
 return {
     "folke/snacks.nvim",
     priority = 1000,
-    lazy = false,
+    -- Defer loading of Snacks until after startup
+    event = "VeryLazy",
 
     ---@module 'snacks'
     ---@type snacks.Config


### PR DESCRIPTION
## Summary
- defer gitsigns loading until buffers open
- load lualine, persistence, and snacks on `VeryLazy`

## Testing
- `stylua lua/optional/gitsigns.lua lua/optional/lualine.lua lua/optional/persistence.lua lua/optional/snacks.lua`
- `selene lua/optional/gitsigns.lua` *(fails: unknown field `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_6850307968c48331913d1ac023de7007